### PR TITLE
Improve SEO semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Mama Mian Pizza Panel</title>
+    <meta name="description" content="Panel de administración de Mama Mian Pizza para gestionar pedidos, inventario y clientes." />
+    <meta name="keywords" content="Mama Mian Pizza, panel, pedidos, inventario, clientes" />
+    <meta property="og:title" content="Mama Mian Pizza Panel" />
+    <meta property="og:description" content="Gestiona pedidos, clientes e inventario de Mama Mian Pizza" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/vite.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/navbar/nabvar.jsx
+++ b/src/components/navbar/nabvar.jsx
@@ -4,7 +4,7 @@ import NotificationBell from '../icons/notificationBell/notificationBell';
 
 function Navbar() {
     return (
-        <div className='navbar'>
+        <nav className='navbar'>
             <div className='brand'>
                 <h2>Pizza Admin</h2>
             </div>
@@ -14,7 +14,7 @@ function Navbar() {
                     <button><CircleUserRound className='icon' size={36}/></button>
                 </div>
             </div>
-        </div>
+        </nav>
     );
 }
 

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -161,6 +161,18 @@
   color: var(--text-secondary);
 }
 
+.sidebar-link {
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  color: inherit;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+}
+
 .sidebar.collapsed .items {
   padding: 12px;
   margin: 0 10px;

--- a/src/components/sidebar/sidebar.jsx
+++ b/src/components/sidebar/sidebar.jsx
@@ -61,13 +61,13 @@ function Sidebar() {
     setIsCollapsed(!isCollapsed);
   };
   return (
-    <div className={`sidebar ${isCollapsed ? 'collapsed' : ''}`}>      {/* Botón para colapsar/expandir */}
+    <nav className={`sidebar ${isCollapsed ? 'collapsed' : ''}`}>      {/* Botón para colapsar/expandir */}
       <button className="sidebar-toggle" onClick={toggleSidebar}>
         {isCollapsed ? <ChevronRight size={28}  color="white" strokeWidth={4} /> : <ChevronLeft size={28}  color="white" strokeWidth={4}/>}
       </button>
 
       <header className="sidebar-header">
-        <img className="sidebar-brand" src={Logo} alt="" />
+        <img className="sidebar-brand" src={Logo} alt="Logo de Mama Mian Pizza" />
         {!isCollapsed && (
           <h1>
             Mama Mian Panel
@@ -101,12 +101,19 @@ function Sidebar() {
             <House size={28} />
             {!isCollapsed && "Inicio"}
           </span>
-        </button>        {/* Changed button to div to prevent nesting errors with NotificationBell */}
-        <div className="items" onClick={() => handleNavigation("/pedidos")} role="button" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && handleNavigation("/pedidos")} title="Pedidos">
-          <span>
-            <ShoppingCart size={28} />
-            {!isCollapsed && "Pedidos"}
-          </span>
+        </button>
+        <div className="items">
+          <button
+            type="button"
+            className="sidebar-link"
+            onClick={() => handleNavigation("/pedidos")}
+            title="Pedidos"
+          >
+            <span>
+              <ShoppingCart size={28} />
+              {!isCollapsed && "Pedidos"}
+            </span>
+          </button>
           <NotificationBell category="pedidos" isCollapsed={isCollapsed} />
         </div>
         
@@ -154,7 +161,7 @@ function Sidebar() {
           <span>Activar notificaciones</span>
         </button>
       )}
-    </div>
+    </nav>
   );
 }
 


### PR DESCRIPTION
## Summary
- make navbar and sidebar use semantic nav elements
- use button inside container for pedidos item to avoid div role
- add sidebar-link styles

## Testing
- `npm run lint` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6840fe1ff7d0832897e5499ce690f588